### PR TITLE
Document browser save_path option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Ferrum::Browser.new(options)
   * `:ws_max_receive_size` (Integer) - How big messages to accept from Chrome
       over the web socket, in bytes. Defaults to 64MB. Incoming messages larger
       than this will cause a `Ferrum::DeadBrowserError`.
+  * `:save_path` (String) - Configure where downloaded files are saved.
 
 
 ## Navigation


### PR DESCRIPTION
I was looking if there was a way to access downloaded files, turns out the work was already done but it wasn't document it. So I've added it.

Here's the [save_path option](https://github.com/rubycdp/ferrum/blob/0a119dae81400c0cd1c0e1675bac29ff58e820a7/lib/ferrum/page.rb#L204).